### PR TITLE
Add model SYNGO:1805 missing due to merged term

### DIFF
--- a/models/SYNGO_1805.ttl
+++ b/models/SYNGO_1805.ttl
@@ -1,0 +1,330 @@
+@prefix : <http://model.geneontology.org/SYNGO_1805#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <http://model.geneontology.org/SYNGO_1805> .
+
+<http://model.geneontology.org/SYNGO_1805> rdf:type owl:Ontology ;
+                                            <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                            <http://geneontology.org/lego/modelstate> "production"^^xsd:string ;
+                                            <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ;
+                                            <http://purl.org/dc/elements/1.1/date> "2017-11-03"^^xsd:string ;
+                                            <https://w3id.org/biolink/vocab/in_taxon> "http://purl.obolibrary.org/obo/NCBITaxon_10116"^^xsd:string ;
+                                            rdfs:comment """Rationale: Fig.4: MyoVb Constitutively Traffics REs (recycling endosomes) in Spines by Interacting with Rab11-FIP2
+Fig.5: MyoVb Mediates Endosome Translocation into Spines during LTP
+
+3/11/2017 Pim
+- I have decided against functionally linking role in RE-localization to the the observed phenomena of AMPAR insertion and spine morphology since not directly shown in paper.. Experimental description: M&M:
+Hippocampal neuron cultures were prepared from E18 rat embryos
+co-IPs of endogenous proteins were done from whole rat brains
+Electrophysiology was done in brain slices from MyoVb Y119G transgenic mice or wild type FVB mice (Charles River)
+
+3/11/2017 Pim
+- Overexpressed Myo5b is of rat species: \"Rat MyoVb full-length cDNA (brain isoform) was amplified by PCR from pcDNA3.1EMyoVb (Provance et al., 2004) \""""^^xsd:string ;
+                                            <http://purl.org/dc/elements/1.1/title> "Myo5b_BP_1805"^^xsd:string ;
+                                            <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://geneontology.org/lego/evidence
+<http://geneontology.org/lego/evidence> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/contributor
+<http://purl.org/dc/elements/1.1/contributor> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/date
+<http://purl.org/dc/elements/1.1/date> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/source
+<http://purl.org/dc/elements/1.1/source> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/pav/providedBy
+<http://purl.org/pav/providedBy> rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://purl.obolibrary.org/obo/BFO_0000050
+<http://purl.obolibrary.org/obo/BFO_0000050> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/BFO_0000066
+<http://purl.obolibrary.org/obo/BFO_0000066> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0002333
+<http://purl.obolibrary.org/obo/RO_0002333> rdf:type owl:ObjectProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://identifiers.org/rgd/621347
+<http://identifiers.org/rgd/621347> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/ECO_0005589
+<http://purl.obolibrary.org/obo/ECO_0005589> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/ECO_0006063
+<http://purl.obolibrary.org/obo/ECO_0006063> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/ECO_0007695
+<http://purl.obolibrary.org/obo/ECO_0007695> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0003674
+<http://purl.obolibrary.org/obo/GO_0003674> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0036466
+<http://purl.obolibrary.org/obo/GO_0036466> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0098978
+<http://purl.obolibrary.org/obo/GO_0098978> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/UBERON_0002421
+<http://purl.obolibrary.org/obo/UBERON_0002421> rdf:type owl:Class .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  http://model.geneontology.org/SYNGO_180501c2db13-9836-444d-9078-3349ef2503fd
+<http://model.geneontology.org/SYNGO_180501c2db13-9836-444d-9078-3349ef2503fd> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/GO_0036466> ;
+                                                                               <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/SYNGO_18051ff85b73-efba-447e-8ba3-8f546deab919> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/SYNGO_180501c2db13-9836-444d-9078-3349ef2503fd> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
+   owl:annotatedTarget <http://model.geneontology.org/SYNGO_18051ff85b73-efba-447e-8ba3-8f546deab919> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/SYNGO_180535734761-83ec-4c6d-8514-215131db9bf0> ,
+                                           <http://model.geneontology.org/SYNGO_1805ab34fb7c-1945-4f41-8011-98afdcc0fae8> ,
+                                           <http://model.geneontology.org/SYNGO_1805b9a215ac-d161-4cd3-b663-aa7571e53285> ;
+   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                 "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+   <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string
+ ] .
+
+
+###  http://model.geneontology.org/SYNGO_180506cd982b-220d-4470-8f8b-042482090245
+<http://model.geneontology.org/SYNGO_180506cd982b-220d-4470-8f8b-042482090245> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/ECO_0006063> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/source> "PMID:18984164"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  http://model.geneontology.org/SYNGO_1805113288c1-cf44-4497-bb64-58cede401fb3
+<http://model.geneontology.org/SYNGO_1805113288c1-cf44-4497-bb64-58cede401fb3> rdf:type owl:NamedIndividual ,
+                                                                                        <http://identifiers.org/rgd/621347> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  http://model.geneontology.org/SYNGO_18051fce1b4d-b872-4c6f-9030-fc68667f8822
+<http://model.geneontology.org/SYNGO_18051fce1b4d-b872-4c6f-9030-fc68667f8822> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/ECO_0007695> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/source> "PMID:18984164"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  http://model.geneontology.org/SYNGO_18051ff85b73-efba-447e-8ba3-8f546deab919
+<http://model.geneontology.org/SYNGO_18051ff85b73-efba-447e-8ba3-8f546deab919> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/GO_0098978> ;
+                                                                               <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/SYNGO_1805a79f1a9c-b61d-4486-8178-86ab281b4652> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/SYNGO_18051ff85b73-efba-447e-8ba3-8f546deab919> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+   owl:annotatedTarget <http://model.geneontology.org/SYNGO_1805a79f1a9c-b61d-4486-8178-86ab281b4652> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/SYNGO_180506cd982b-220d-4470-8f8b-042482090245> ,
+                                           <http://model.geneontology.org/SYNGO_180580bf5bc0-9d3c-4f06-b7af-95ded3b084a8> ,
+                                           <http://model.geneontology.org/SYNGO_1805b2274889-f301-4d99-83a3-265a70f672e3> ;
+   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                 "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+   <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string
+ ] .
+
+
+###  http://model.geneontology.org/SYNGO_180530d866ac-0155-4be7-b7d4-142a3dbb32bf
+<http://model.geneontology.org/SYNGO_180530d866ac-0155-4be7-b7d4-142a3dbb32bf> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/ECO_0006063> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/source> "PMID:18984164"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  http://model.geneontology.org/SYNGO_180535734761-83ec-4c6d-8514-215131db9bf0
+<http://model.geneontology.org/SYNGO_180535734761-83ec-4c6d-8514-215131db9bf0> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/ECO_0006063> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/source> "PMID:18984164"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  http://model.geneontology.org/SYNGO_180573db9c1d-fe42-4252-92e5-eee04c307211
+<http://model.geneontology.org/SYNGO_180573db9c1d-fe42-4252-92e5-eee04c307211> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/ECO_0007695> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/source> "PMID:18984164"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  http://model.geneontology.org/SYNGO_180580bf5bc0-9d3c-4f06-b7af-95ded3b084a8
+<http://model.geneontology.org/SYNGO_180580bf5bc0-9d3c-4f06-b7af-95ded3b084a8> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/ECO_0007695> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/source> "PMID:18984164"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  http://model.geneontology.org/SYNGO_18058b5a0e6e-c973-43dd-b644-5ab6ab765af1
+<http://model.geneontology.org/SYNGO_18058b5a0e6e-c973-43dd-b644-5ab6ab765af1> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/ECO_0006063> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/source> "PMID:18984164"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  http://model.geneontology.org/SYNGO_180593a03691-c3f9-4f7b-9aa3-32349d6d5701
+<http://model.geneontology.org/SYNGO_180593a03691-c3f9-4f7b-9aa3-32349d6d5701> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/ECO_0005589> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/source> "PMID:18984164"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  http://model.geneontology.org/SYNGO_1805a718d74c-684d-4a05-ad8d-a72188591190
+<http://model.geneontology.org/SYNGO_1805a718d74c-684d-4a05-ad8d-a72188591190> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                               <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/SYNGO_180501c2db13-9836-444d-9078-3349ef2503fd> ;
+                                                                               <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/SYNGO_1805113288c1-cf44-4497-bb64-58cede401fb3> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/SYNGO_1805a718d74c-684d-4a05-ad8d-a72188591190> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+   owl:annotatedTarget <http://model.geneontology.org/SYNGO_180501c2db13-9836-444d-9078-3349ef2503fd> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/SYNGO_180573db9c1d-fe42-4252-92e5-eee04c307211> ,
+                                           <http://model.geneontology.org/SYNGO_18058b5a0e6e-c973-43dd-b644-5ab6ab765af1> ,
+                                           <http://model.geneontology.org/SYNGO_180593a03691-c3f9-4f7b-9aa3-32349d6d5701> ;
+   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                 "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+   <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/SYNGO_1805a718d74c-684d-4a05-ad8d-a72188591190> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/SYNGO_1805113288c1-cf44-4497-bb64-58cede401fb3> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/SYNGO_18051fce1b4d-b872-4c6f-9030-fc68667f8822> ,
+                                           <http://model.geneontology.org/SYNGO_180530d866ac-0155-4be7-b7d4-142a3dbb32bf> ,
+                                           <http://model.geneontology.org/SYNGO_1805b66c08fe-295e-455a-a07a-2844d43c014c> ;
+   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                 "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+   <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string
+ ] .
+
+
+###  http://model.geneontology.org/SYNGO_1805a79f1a9c-b61d-4486-8178-86ab281b4652
+<http://model.geneontology.org/SYNGO_1805a79f1a9c-b61d-4486-8178-86ab281b4652> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/UBERON_0002421> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  http://model.geneontology.org/SYNGO_1805ab34fb7c-1945-4f41-8011-98afdcc0fae8
+<http://model.geneontology.org/SYNGO_1805ab34fb7c-1945-4f41-8011-98afdcc0fae8> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/ECO_0007695> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/source> "PMID:18984164"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  http://model.geneontology.org/SYNGO_1805b2274889-f301-4d99-83a3-265a70f672e3
+<http://model.geneontology.org/SYNGO_1805b2274889-f301-4d99-83a3-265a70f672e3> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/ECO_0005589> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/source> "PMID:18984164"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  http://model.geneontology.org/SYNGO_1805b66c08fe-295e-455a-a07a-2844d43c014c
+<http://model.geneontology.org/SYNGO_1805b66c08fe-295e-455a-a07a-2844d43c014c> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/ECO_0005589> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/source> "PMID:18984164"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  http://model.geneontology.org/SYNGO_1805b9a215ac-d161-4cd3-b663-aa7571e53285
+<http://model.geneontology.org/SYNGO_1805b9a215ac-d161-4cd3-b663-aa7571e53285> rdf:type owl:NamedIndividual ,
+                                                                                        <http://purl.obolibrary.org/obo/ECO_0005589> ;
+                                                                               <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2666-0758"^^xsd:string ,
+                                                                                                                             "http://orcid.org/0000-0002-6153-3586"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/date> "2022-06-17"^^xsd:string ;
+                                                                               <http://purl.org/dc/elements/1.1/source> "PMID:18984164"^^xsd:string ;
+                                                                               <http://purl.org/pav/providedBy> "https://syngo.vu.nl"^^xsd:string .
+
+
+###  Generated by the OWL API (version 4.2.7.20161016-0911) https://github.com/owlcs/owlapi


### PR DESCRIPTION
Model SYNGO:1805 was previously omitted due to annotated GO term GO:0099090 being merged with GO:0036466. I updated this to GO:0099090's replaced_by term GO:0036466.